### PR TITLE
Add an monitor option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ fn activate(application: &Application) {
         gtk_layer_shell::set_keyboard_interactivity(&window, true);
     }
     
+    // Initialize gdk::Display by default value, which is decided by the compositor.
     let display = gdk::Display::default().expect("[ERROR] Could not get default display.");
 
     // Loads the monitor variable from config, default is 0.

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,13 @@ fn activate(application: &Application) {
     if config::try_get("hybrid", "allow_keyboard", true).0 == "true" {
         gtk_layer_shell::set_keyboard_interactivity(&window, true);
     }
+    
+    let display = gdk::Display::default().expect("[ERROR] Could not get default display.");
+
+    let config_monitor = config::try_get("hybrid", "monitor", false);
+    let monitor = display.monitor(config_monitor.1).expect("[ERROR] Could not find monitor.");
+
+    gtk_layer_shell::set_monitor(&window, &monitor);
 
     // For transparency to work.
     window.set_app_paintable(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,13 @@ fn activate(application: &Application) {
     
     let display = gdk::Display::default().expect("[ERROR] Could not get default display.");
 
+    // Loads the monitor variable from config, default is 0.
     let config_monitor = config::try_get("hybrid", "monitor", false);
-    let monitor = display.monitor(config_monitor.1).expect("[ERROR] Could not find monitor.");
 
+    // Gets the actual gdk::Monitor from configured number.
+    let monitor = display.monitor(config_monitor.1).expect("[ERROR] Could not find monitor.");
+    
+    // Sets which monitor should be used for the bar.
     gtk_layer_shell::set_monitor(&window, &monitor);
 
     // For transparency to work.


### PR DESCRIPTION
Default monitor is 0.
Although, looking at the code, I couldn't help to notice that making `config::try_get` return a Option instead of a plain pair could be beneficial and would make more sense.
If the value would had been found, just return `None` which can be easily put through `match` or `if let`

Code I wrote could be rewritten as:
```
if some(config_monitor) = config::try_get("hybrid", "monitor", false) {
  let monitor = display.monitor(config_monitor.1).expect("..");
  gtk_layer_shell::set_monitor(&window, &monitor);
}
```
So that gdk::Display can stay set to default (set by the compositor).

> also sorry for pushing in 3 commits, not trying to farm, am just committing without checking first