### PR TITLE
Add namespace option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,15 @@ fn activate(application: &Application) {
         gtk_layer_shell::set_keyboard_interactivity(&window, c_allow_keyboard == "true");
     }
 
+    // Allows for specifing the namespace of the layer.
+    // The default is "gtk-layer-shell" to not break existing configs.
+    let mut namespace = String::from("gtk-layer-shell");
+    if let Some(c_namespace) = config::try_get("hybrid", "namespace", true, false).string
+    {
+        namespace = c_namespace;
+    }
+    gtk_layer_shell::set_namespace(&window, &namespace);
+
     // Initialize gdk::Display by default value, which is decided by the compositor.
     let display = Display::default()
         .expect("[ERROR] Could not get default display, is your compositor doing okay?\n");


### PR DESCRIPTION
Currently, the namespace for the layer is `gtk-layer-shell`, which is the default namespace in gtk-layer-shell. This PR adds an option to change the namespace and sets the default to `gtk-layer-shell` to not break any existing configs and to allow changing the default easily in the future.
I tested the changes successfully on my local setup with hyprland.