### PR TITLE
Added a flake.nix + flake.lock with HybridBar Package + devShells

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        inherit (nixpkgs) lib;
+
+        pkgs = nixpkgs.legacyPackages.${system};
+        rpath = lib.makeLibraryPath (with pkgs; [
+          fontconfig
+          wayland
+        ]);
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "hybrid-bar";
+          inherit ((lib.importTOML (self + "/Cargo.toml")).package) version;
+
+          src = self;
+
+          cargoLock.lockFile = self + "/Cargo.lock";
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            gtk-layer-shell
+            gtk3
+          ];
+
+          postFixup = ''
+            patchelf $out/bin/hybrid-bar --add-rpath ${rpath}
+          '';
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            rustc
+            cargo
+            gtk-layer-shell
+            gtk3
+            pkg-config
+          ];
+
+          LD_LIBRARY_PATH = rpath;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Regarding #7 
I have added a flake.nix file to the repository that packages HybridBar and [devShells](https://github.com/numtide/devshell)  for the program. 

Regarding this https://github.com/vars1ty/HybridBar/issues/7#issuecomment-1271936368
You can use [`nix flake show`](https://nix.dev/manual/nix/2.25/command-ref/new-cli/nix3-flake-show) and [ `nix run`](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-run) on repository directory or with arguements pointing to my version of the fork ( `nix run github:sandptel/HybridBar ` )  that would run the Hybrid Bar's nix package directly on your system on a temporary shell.

![image](https://github.com/user-attachments/assets/684d352e-f8e8-40d1-8e89-b66ad5f6091f)



